### PR TITLE
Adding support for multiple hooks installation in a single command

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,4 +8,4 @@ docs/
 CONTRIBUTING.md
 DOCS_TEMPLATE.md
 registry.json
-.gitbook.yml
+.gitbook.yaml

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -38,19 +38,6 @@ const getConfig = (): Config => {
 };
 
 /**
- * Get Hook by Url
- */
-const getHookByUrl = async (url: string, name: string) => {
-  const hookResponse = await axios.get(url, { timeout: 10000 });
-
-  if (hookResponse.status !== 200) {
-    console.log(chalk.red(`Failed to fetch hook "${name}".`));
-    return;
-  }
-  return hookResponse.data;
-};
-
-/**
  * Initialize configuration
  */
 async function handleInit() {
@@ -93,7 +80,11 @@ const handleAdd = async (hookNames: string[]) => {
 
     const missingHooks = hookNames.filter((name) => !availableHookNames.includes(name));
     if (missingHooks.length > 0) {
-      console.log(chalk.red(`The following hooks are not available: ${missingHooks.join(", ")}`));
+      if (hookNames.length > 1) {
+        console.log(chalk.red(`The following hooks are not available: ${missingHooks.join(", ")}`));
+      } else {
+        console.log(chalk.red(`${missingHooks[0]} is not available. use 'hookcn list' to see available hooks.`));
+      }
       console.log(chalk.red("Operation Aborted!"));
       return;
     }
@@ -139,6 +130,14 @@ const handleAdd = async (hookNames: string[]) => {
       console.log(chalk.green(`✓ Hook "${hookName}" installed successfully to ${config.destination}`));
     }
     console.log(chalk.magentaBright(`✓ Installation complete!`));
+    console.log(" ");
+
+    if (hookNames.length > 1) {
+      console.log(chalk.gray(`→ Documentation: ${DOCS_BASE_URL}`));
+      return;
+    }
+
+    console.log(chalk.gray(`→ Learn about ${hookNames[0]}: ${DOCS_BASE_URL + hookNames[0]}`));
   } catch (error) {
     console.log(chalk.red(`Failed to install hooks. Please check your internet connection.`));
   }
@@ -152,9 +151,9 @@ const handleList = async () => {
 
   try {
     const response = await axios.get(REGISTRY_URL);
+    console.log(chalk.blue("✓ Collecting Available hooks:"));
     const hooks: { name: string }[] = response.data.sort((a: any, b: any) => a.name.localeCompare(b.name));
 
-    console.log(chalk.blue("Available Hooks:"));
     hooks.forEach((hook) => {
       const userHookPath = path.join(config.destination, `${hook.name}.ts`);
       if (fs.existsSync(userHookPath)) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hookcn",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hookcn",
-      "version": "1.0.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^1.8.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hookcn",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "A CLI tool that instantly copies React hooks into your codebase",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
### CLI Enhancements:
* Updated the `handleAdd` function to support adding multiple hooks simultaneously, improving usability for batch operations. The command now accepts an array of hook names and provides detailed feedback for missing or unavailable hooks. [[1]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebL71-R101) [[2]](diffhunk://#diff-fa0959877ee00654f56c4e0590858cd6789128f282c322947dde3564750fbaebL121-R142)
* Changed the `add` command syntax in the CLI from `<hookName>` to `[hookNames...]` to reflect the new multi-hook functionality.
* Improved the `handleList` function by adding a message indicating the collection of available hooks, enhancing user feedback.

### Codebase Simplification:
* Removed unnecessary `__filename` and `__dirname` definitions in `cli/index.ts`, as they were not being used.

Resolves #3 